### PR TITLE
[NON-JIRA] Add rollback when user creation fails

### DIFF
--- a/src/common/DfT.ZEV.Common.MVC.Authentication/Identity/Implementations/IdentityPlatform.cs
+++ b/src/common/DfT.ZEV.Common.MVC.Authentication/Identity/Implementations/IdentityPlatform.cs
@@ -107,4 +107,11 @@ internal sealed class IdentityPlatform : IIdentityPlatform
 
         await _googleIdentityApiClient.ChangePasswordWithToken(request);
     }
+
+    public async Task DeleteUserAsync(Guid userId, string tenantId)
+    {
+        await FirebaseAuth.DefaultInstance.TenantManager
+            .AuthForTenant(tenantId)
+            .DeleteUserAsync(userId.ToString());
+    }
 }

--- a/src/common/DfT.ZEV.Common.MVC.Authentication/Identity/Interfaces/IIdentityPlatform.cs
+++ b/src/common/DfT.ZEV.Common.MVC.Authentication/Identity/Interfaces/IIdentityPlatform.cs
@@ -6,6 +6,7 @@ namespace DfT.ZEV.Common.MVC.Authentication.Identity;
 public interface IIdentityPlatform
 {
     public ValueTask<UserRecord> CreateUser(UserRecordArgs userRecordArgs, string tenantId);
+    public Task DeleteUserAsync(Guid userId, string tenantId);
     public Task SetUserClaimsAsync(Guid userId, IReadOnlyDictionary<string, object> claims, string tenantId);
     public Task<string> GetPasswordResetToken(Guid userId, string tenantId);
     public Task<string> GetPasswordResetToken(string email, string tenantId);

--- a/src/core/DfT.ZEV.Core.Application/Accounts/DTO/AuthorizeUserResult.cs
+++ b/src/core/DfT.ZEV.Core.Application/Accounts/DTO/AuthorizeUserResult.cs
@@ -1,6 +1,0 @@
-namespace DfT.ZEV.Core.Application.Accounts.DTO;
-
-public class AuthorizeUserResult
-{
-    public string Token { get; set; }
-}

--- a/src/services/apis/organisations/DfT.ZEV.Services.Organisations.Api/Features/Accounts/MapAccountsEndpoints.cs
+++ b/src/services/apis/organisations/DfT.ZEV.Services.Organisations.Api/Features/Accounts/MapAccountsEndpoints.cs
@@ -16,8 +16,8 @@ public static class MapAccountsEndpointsExtension
         app.MapPost("/accounts/", CreateManufacturerAccount)
             .WithTags("Accounts");
 
-        app.MapPost("/accounts/{id}/permissions", GetUserPermissionsForManufacturer)
-       .WithTags("Accounts");
+        app.MapGet("/accounts/{id}/permissions", GetUserPermissionsForManufacturer)
+            .WithTags("Accounts");
 
         return app;
     }


### PR DESCRIPTION
This PR Contains:
* Adding rollback when user creation fails, previous implementation just leaved user in identity.
* Small cleanup
* Changed endpoint /accounts/{id}/permissions [POST] -> [GET]